### PR TITLE
Fixed (get|set)TypeParser annotations

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -87,13 +87,24 @@ export class Client extends EventEmitter {
 export { Pool }
 export var defaults: Config;
 
+/**
+ * The following functions are used to convert a textual or binary
+ * representation of a PostgreSQL result value into a JavaScript type.
+ *
+ * The oid can be obtained via the following sql query:
+ *   `SELECT oid FROM pg_type WHERE typname = 'TYPE_NAME_HERE';`
+ */
 export namespace types {
-  /**
-   * returns a function used to convert a specific type (specified by oid) into a result javascript type
-   * note: the oid can be obtained via the following sql query:
-   * `SELECT oid FROM pg_type WHERE typname = 'TYPE_NAME_HERE';`
-   */
-  export function getTypeParser(oid: number, format?: 'text' | 'binary');
-  export function setTypeParser(oid: number, format: 'text' | 'binary', parseFn: (value: string) => any);
-  export function setTypeParser(oid: number, parseFn: (value: string) => any);
+  type TypeParserText = (value: string) => any;
+  type TypeParserBinary = (value: Buffer) => any;
+
+  export function getTypeParser(oid: number, format: 'text' | 'binary'): TypeParserText | TypeParserBinary;
+  export function setTypeParser(oid: number, format: 'text' | 'binary', parseFn: TypeParserText | TypeParserBinary): void;
+
+  export function getTypeParser(oid: number, format?: 'text'): TypeParserText;
+  export function setTypeParser(oid: number, format: 'text', parseFn: TypeParserText): void;
+  export function setTypeParser(oid: number, parseFn: TypeParserText): void;
+
+  export function getTypeParser(oid: number, format: 'binary'): TypeParserBinary;
+  export function setTypeParser(oid: number, format: 'binary', parseFn: TypeParserBinary): void;
 }


### PR DESCRIPTION
Previous return type annotations where missing, which made compilation with strict(er) tsconfic settings impossible. I also fixed the parameter type of the type parser, which is different between `'text'` and `'binary'`.

Please review my changes if possible. :smiley: 
