### PR TITLE
Made query args optional. Added rows property on query result.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -47,6 +47,7 @@ export interface ResultBuilder {
 
 export class Query extends EventEmitter {
   text: string;
+  rows: { [column: string]: any }[];
   values: any[];
 
   on(event: 'row', listener: (row: any, result: ResultBuilder) => void): this;
@@ -68,8 +69,8 @@ export class Client extends EventEmitter {
   ssl: boolean;
 
   query(query: QueryConfig, callback?: QueryCallback): Query;
-  query(text: string, callback: QueryCallback): Query;
-  query(text: string, values: any[], callback: QueryCallback): Query;
+  query(text: string, callback?: QueryCallback): Query;
+  query(text: string, values: any[], callback?: QueryCallback): Query;
 
   connect(callback?: ClientConnectCallback): void;
   end(): void;
@@ -93,7 +94,7 @@ export namespace types {
    * note: the oid can be obtained via the following sql query:
    * `SELECT oid FROM pg_type WHERE typname = 'TYPE_NAME_HERE';`
    */
-  export function getTypeParser(oid: number, format?: 'text' | 'binary');
-  export function setTypeParser(oid: number, format: 'text' | 'binary', parseFn: (value: string) => any);
-  export function setTypeParser(oid: number, parseFn: (value: string) => any);
+  export function getTypeParser(oid: number, format?: 'text' | 'binary'):any;
+  export function setTypeParser(oid: number, format: 'text' | 'binary', parseFn: (value: string) => any):void;
+  export function setTypeParser(oid: number, parseFn: (value: string) => any):void;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,6 @@
     "tests/*.ts"
   ],
   "files": [
-    "typings/index.d.ts",
     "index.d.ts",
     "tests/client.ts",
     "tests/defaults.ts",


### PR DESCRIPTION
Query can also be called with:
- a string arg only
- a string and an array argument

(see https://github.com/brianc/node-postgres/blob/master/lib/client.js - line 323 ff)

The object returned by query has (beside others) a rows-property, see:
https://github.com/brianc/node-postgres/blob/master/lib/query.js - line 23
https://github.com/brianc/node-pg-pool - Example for chapter "connect"

Note: I just added any, respectively void for the functions mentioned in https://github.com/types/typed-pg/pull/12 and leave the more detailed changes for that other PR.
