### PR TITLE
Update typings.json and misc

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -1,6 +1,8 @@
 {
   "extends": "tslint-config-typings",
   "rules": {
-    "no-console": 0
+    "no-console": [
+      false
+    ]
   }
 }

--- a/typings.json
+++ b/typings.json
@@ -2,18 +2,9 @@
   "name": "pg",
   "main": "index.d.ts",
   "author": "goenning <oenning.ti@gmail.com>",
-  "keywords": [
-    "TypeScript",
-    "typings",
-    "pg",
-    "node-postgres",
-    "postgres"
-  ],
-  "description": "The TypeScript definition for pg (brianc/node-postgres)",
-  "url": "https://github.com/goenning/typed-pg/",
-  "license": "MIT",
+  "homepage": "https://github.com/brianc/node-postgres",
   "dependencies": {
-    "pg-pool": "github:typed-typings/npm-pg-pool#32c9470c06a0c203bb3e1c203210f88766d44853"
+    "pg-pool": "registry:npm/pg-pool#1.3.1+20160723033700"
   },
   "devDependencies": {},
   "globalDependencies": {

--- a/typings.json
+++ b/typings.json
@@ -1,6 +1,7 @@
 {
   "name": "pg",
   "main": "index.d.ts",
+  "version": "6.0.2",
   "author": "goenning <oenning.ti@gmail.com>",
   "homepage": "https://github.com/brianc/node-postgres",
   "dependencies": {
@@ -8,6 +9,6 @@
   },
   "devDependencies": {},
   "globalDependencies": {
-    "node": "registry:env/node#4.0.0+20160622202520"
+    "node": "registry:env/node#6.0.0+20160723033700"
   }
 }


### PR DESCRIPTION
I updated the `pg-pool` to use the registry instead of directly referencing github.
Also remove some entries in `typings.json` because it is not used, and added `homepage`
I don't know which `version` this is typed for (although I guess it is '6.0.2' https://github.com/typings/registry/pull/660/files). You can add that in.

I also kept `author` in there although it also doesn't do anything.

Last thing is I didn't update `env~node` to v6 because I don't know if that's what you want.

🌷 
